### PR TITLE
feat: Initialize block pointers for Q, K, V in flash_fwd_kernel

### DIFF
--- a/assignment/assignment2-systems/cs336_systems/flash_attention.py
+++ b/assignment/assignment2-systems/cs336_systems/flash_attention.py
@@ -18,3 +18,35 @@ def flash_fwd_kernel(
     K_TITLE_SIZE: tl.constexpr,
     is_causal: tl.constexpr):
     # 块索引
+    query_title_index = tl.program_id(0)
+    batch_index = tl.program_id(1)
+
+    # 块信息
+    Q_block_ptr = tl.make_block_ptr(
+        Q_ptr + batch_index * stride_qb,
+        shape = (N_QUERIES, D),
+        strides = (stride_qq, stride_qd),
+        offsets = (query_title_index * Q_TITLE_SIZE, 0),
+        block_shape = (Q_TITLE_SIZE, D),
+        order = (1, 0),
+    )
+
+    K_block_ptr = tl.make_block_ptr(
+        K_ptr + batch_index * stride_kb,
+        shape = (N_KEYS, D),
+        strides = (stride_kk, stride_kd),
+        offsets = (0, 0),
+        block_shape = (K_TITLE_SIZE, D),
+        order = (1, 0),
+    )
+
+    V_block_ptr = tl.make_block_ptr(
+        V_ptr + batch_index * stride_vb,
+        shape = (N_KEYS, D),
+        strides = (stride_vk, stride_vd),
+        offsets = (0, 0),
+        block_shape = (K_TITLE_SIZE, D),
+        order = (1, 0)
+    )
+
+    


### PR DESCRIPTION
Initialize `tl.make_block_ptr` for query, key, and value tensors within the `flash_fwd_kernel`. This sets up the necessary memory access patterns for processing data in blocks, a foundational step for the Flash Attention implementation.